### PR TITLE
Update train-on-cifar.lua

### DIFF
--- a/train-on-cifar/train-on-cifar.lua
+++ b/train-on-cifar/train-on-cifar.lua
@@ -179,6 +179,7 @@ testData.data = testData.data:reshape(tesize,3,32,32)
 --
 
 print '<trainer> preprocessing data (color space + normalization)'
+collectgarbage()
 
 -- preprocess trainSet
 normalization = nn.SpatialContrastiveNormalization(1, image.gaussian1D(7))


### PR DESCRIPTION
Need to `collectgarbage()` or the program will fill the memory if the option `-full` is chosen.