### PR TITLE
Fix padding on first convolutional pooling layer.

### DIFF
--- a/train-a-digit-classifier/train-on-mnist.lua
+++ b/train-a-digit-classifier/train-on-mnist.lua
@@ -80,14 +80,14 @@ if opt.network == '' then
       -- stage 1 : mean suppresion -> filter bank -> squashing -> max pooling
       model:add(nn.SpatialConvolutionMM(1, 32, 5, 5))
       model:add(nn.Tanh())
-      model:add(nn.SpatialMaxPooling(3, 3, 3, 3))
+      model:add(nn.SpatialMaxPooling(3, 3, 3, 3, 1, 1))
       -- stage 2 : mean suppresion -> filter bank -> squashing -> max pooling
       model:add(nn.SpatialConvolutionMM(32, 64, 5, 5))
       model:add(nn.Tanh())
       model:add(nn.SpatialMaxPooling(2, 2, 2, 2))
       -- stage 3 : standard 2-layer MLP:
-      model:add(nn.Reshape(64*2*2))
-      model:add(nn.Linear(64*2*2, 200))
+      model:add(nn.Reshape(64*3*3))
+      model:add(nn.Linear(64*3*3, 200))
       model:add(nn.Tanh())
       model:add(nn.Linear(200, #classes))
       ------------------------------------------------------------


### PR DESCRIPTION
Prevents row / col loss during 1st and more importantly 2nd max pooling steps. Incorporates ~30% more pixels from the input image in the classification, namely rows / cols 29-32. Don't see a major difference in global correct % under default training options. Related issue: #45 